### PR TITLE
Add azure, support URL

### DIFF
--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -2,6 +2,8 @@ const microsoftDocumentationSites = [
     "docs.microsoft.com",
     "msdn.microsoft.com",
     "learn.microsoft.com",
+    "azure.microsoft.com",
+    "support.microsoft.com",
 ];
 
 export function isMicrosoftDocumentationUrl(url: URL): boolean {

--- a/test/url-utils.spec.ts
+++ b/test/url-utils.spec.ts
@@ -6,7 +6,7 @@ import {
 
 describe("UrlUtils", () => {
     describe("isMicrosoftDocumentationUrl", () => {
-        it("should return true for msdn.microsoft.com, docs.microsoft.com, and learn.microsoft.com", () => {
+        it("should return true for msdn.microsoft.com, docs.microsoft.com, learn.microsoft.com, azure.microsoft.com, and support.microsoft.com", () => {
             expect(
                 isMicrosoftDocumentationUrl(
                     new URL("https://learn.microsoft.com/abcd")
@@ -20,6 +20,16 @@ describe("UrlUtils", () => {
             expect(
                 isMicrosoftDocumentationUrl(
                     new URL("https://msdn.microsoft.com/abcd")
+                )
+            ).toBe(true);
+            expect(
+                isMicrosoftDocumentationUrl(
+                    new URL("https://azure.microsoft.com/abcd")
+                )
+            ).toBe(true);
+            expect(
+                isMicrosoftDocumentationUrl(
+                    new URL("https://support.microsoft.com/abcd")
                 )
             ).toBe(true);
         });

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
             "https://docs.microsoft.com/*",
             "https://msdn.microsoft.com/*",
             "https://learn.microsoft.com/*",
+            "https://azure.microsoft.com/*",
+            "https://support.microsoft.com/*",
         ],
         background: {
             service_worker: "background.ts",


### PR DESCRIPTION
Hi, I have added domains supported in the https://chromewebstore.google.com/detail/ffs-msdn-in-english/ddaknggefjjgpnlhiejepbiplceedmfl which is not ported to the new manifest.